### PR TITLE
fix: missing prettier import in recommended

### DIFF
--- a/src/configs/angular-recommended.ts
+++ b/src/configs/angular-recommended.ts
@@ -1,41 +1,40 @@
-import ngrx from '@ngrx/eslint-plugin/v9'
+import ngrx from "@ngrx/eslint-plugin/v9";
 import angular from "angular-eslint";
 import tsEslint from "typescript-eslint";
 
-import { ignores } from '../utils';
-import recommendedConfig from './recommended';
+import { ignores } from "../utils";
+import recommendedConfig from "./recommended";
 
-export default tsEslint.config(
-  {
-    name: "devmy-angular-ts-recommended",
-    ignores,
-    files: ["**/*.ts"],
-    extends: [
-      ...ngrx.configs.all,
-      ...angular.configs.tsRecommended,
-      recommendedConfig,
+export default tsEslint.config({
+  name: "devmy-angular-ts-recommended",
+  ignores,
+  files: ["**/*.ts"],
+  extends: [
+    ...ngrx.configs.all,
+    ...angular.configs.tsRecommended,
+    recommendedConfig,
+  ],
+  processor: angular.processInlineTemplates,
+  rules: {
+    "@angular-eslint/directive-selector": [
+      "error",
+      {
+        type: "attribute",
+        prefix: "app",
+        style: "camelCase",
+      },
     ],
-    processor: angular.processInlineTemplates,
-    rules: {
-      '@angular-eslint/directive-selector': [
-        'error',
-        {
-          type: 'attribute',
-          prefix: 'app',
-          style: 'camelCase',
-        },
-      ],
-      '@angular-eslint/component-selector': [
-        'error',
-        {
-          type: 'element',
-          prefix: 'app',
-          style: 'kebab-case',
-        },
-      ],
-      "@angular-eslint/component-class-suffix": [
-        "error", { suffixes: ["Page", "Component"] }
-      ],
-    },
+    "@angular-eslint/component-selector": [
+      "error",
+      {
+        type: "element",
+        prefix: "app",
+        style: "kebab-case",
+      },
+    ],
+    "@angular-eslint/component-class-suffix": [
+      "error",
+      { suffixes: ["Page", "Component"] },
+    ],
   },
-);
+});

--- a/src/configs/angular-template-recommended.ts
+++ b/src/configs/angular-template-recommended.ts
@@ -1,7 +1,7 @@
 import angular from "angular-eslint";
 import tsEslint from "typescript-eslint";
 
-import { ignores } from '../utils';
+import { ignores } from "../utils";
 
 export default tsEslint.config({
   name: "devmy-angular-template-recommended",
@@ -13,6 +13,6 @@ export default tsEslint.config({
   ],
   rules: {
     "@angular-eslint/template/attributes-order": "error",
-    "@angular-eslint/template/prefer-self-closing-tags": "error"
-  }
+    "@angular-eslint/template/prefer-self-closing-tags": "error",
+  },
 });

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -1,76 +1,81 @@
-import eslint from '@eslint/js';
-import stylisticTs from '@stylistic/eslint-plugin-ts'
-import { FlatConfig } from '@typescript-eslint/utils/ts-eslint';
-import simpleImportSort from 'eslint-plugin-simple-import-sort';
+import eslint from "@eslint/js";
+import stylisticTs from "@stylistic/eslint-plugin-ts";
+import { FlatConfig } from "@typescript-eslint/utils/ts-eslint";
+import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
+import simpleImportSort from "eslint-plugin-simple-import-sort";
 import sonar from "eslint-plugin-sonarjs";
-import eslintPluginUnicorn from 'eslint-plugin-unicorn';
-import tsEslint from 'typescript-eslint';
+import eslintPluginUnicorn from "eslint-plugin-unicorn";
+import tsEslint from "typescript-eslint";
 
-import { ignores } from '../utils';
+import { ignores } from "../utils";
 
 export default tsEslint.config({
   name: "devmy-recommended",
   ignores,
-  plugins: { 
+  plugins: {
     sonar,
     unicorn: eslintPluginUnicorn,
-    'simple-import-sort': simpleImportSort,
-    '@stylistic': stylisticTs
+    "simple-import-sort": simpleImportSort,
+    "@stylistic": stylisticTs,
   },
-  files: ['**/*.ts'],
+  files: ["**/*.ts"],
   extends: [
     eslint.configs.recommended,
     sonar.configs.recommended,
     ...tsEslint.configs.recommended,
     ...tsEslint.configs.stylistic,
+    eslintPluginPrettierRecommended,
   ],
   rules: {
     "@stylistic/space-before-blocks": "error",
     "@stylistic/padding-line-between-statements": [
       "error",
-        {
-          "blankLine": "always",
-          "prev": "*",
-          "next": "return"
-        }
+      {
+        blankLine: "always",
+        prev: "*",
+        next: "return",
+      },
     ],
     "@typescript-eslint/array-type": ["error", { default: "array-simple" }],
-    '@typescript-eslint/ban-ts-comment': 0,
+    "@typescript-eslint/ban-ts-comment": 0,
     "@typescript-eslint/explicit-member-accessibility": "error",
-    '@typescript-eslint/explicit-function-return-type': 'error',
-     "@typescript-eslint/max-params": ["error", { max: 3 }],
-    'arrow-body-style': ['error', 'as-needed'], 
-    'curly': 'error',
-    'default-case': 'error',
-    'eqeqeq': 'error', 
-    'id-length': ['error', { 'min': 2, 'exceptions': ['x', 'y', 'z', 'i', 'j', '_'] }],
-    'max-classes-per-file': ['error', 2],
-    'max-depth': ['error', 4],
-    'max-lines': [1, { max: 150 }],
-    'max-lines-per-function': [1, { max: 40 }], 
-    'max-nested-callbacks': ['error', 3], 
-    'no-console': 'error',
-    'no-magic-numbers': [
-      "error", 
-      { 
-        "detectObjects": false,
-        "ignoreArrayIndexes": true, 
-        "ignoreDefaultValues": true, 
-        "ignoreClassFieldInitialValues": true, 
-        "ignore": [0, 1]
-      }
+    "@typescript-eslint/explicit-function-return-type": "error",
+    "@typescript-eslint/max-params": ["error", { max: 3 }],
+    "arrow-body-style": ["error", "as-needed"],
+    curly: "error",
+    "default-case": "error",
+    eqeqeq: "error",
+    "id-length": [
+      "error",
+      { min: 2, exceptions: ["x", "y", "z", "i", "j", "_"] },
     ],
-    'no-multi-assign': 'error',
-    'no-nested-ternary': 'error',
-    'no-shadow': 'off',
-    'no-undefined': 'error', 
-    'no-unneeded-ternary': 'error',
-    'simple-import-sort/exports': 'error',
-    'simple-import-sort/imports': 'error',
-    'yoda': 'error',
-    'no-unused-vars': 'off',
+    "max-classes-per-file": ["error", 2],
+    "max-depth": ["error", 4],
+    "max-lines": [1, { max: 150 }],
+    "max-lines-per-function": [1, { max: 40 }],
+    "max-nested-callbacks": ["error", 3],
+    "no-console": "error",
+    "no-magic-numbers": [
+      "error",
+      {
+        detectObjects: false,
+        ignoreArrayIndexes: true,
+        ignoreDefaultValues: true,
+        ignoreClassFieldInitialValues: true,
+        ignore: [0, 1],
+      },
+    ],
+    "no-multi-assign": "error",
+    "no-nested-ternary": "error",
+    "no-shadow": "off",
+    "no-undefined": "error",
+    "no-unneeded-ternary": "error",
+    "simple-import-sort/exports": "error",
+    "simple-import-sort/imports": "error",
+    yoda: "error",
+    "no-unused-vars": "off",
     "unicorn/better-regex": "error",
     "unicorn/explicit-length-check": "error",
     "unicorn/no-abusive-eslint-disable": "error",
-  }
+  },
 }) as FlatConfig.Config;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,24 @@
 import fs from "fs";
 
-import angularRecommendedConfig from './configs/angular-recommended';
-import angularTemplateRecommendedConfig from './configs/angular-template-recommended';
-import recommendedConfig from './configs/recommended';
+import angularRecommendedConfig from "./configs/angular-recommended";
+import angularTemplateRecommendedConfig from "./configs/angular-template-recommended";
+import recommendedConfig from "./configs/recommended";
 
-const pkg: Record<string, string> = JSON.parse(fs.readFileSync('./package.json', "utf8"));
+const pkg: Record<string, string> = JSON.parse(
+  fs.readFileSync("./package.json", "utf8"),
+);
 
 const plugin = {
   meta: {
     name: pkg.name,
-    version: pkg.version
+    version: pkg.version,
   },
   configs: {
     recommended: recommendedConfig,
-    'angular-recommended': angularRecommendedConfig,
-    'angular-template-recommended': angularTemplateRecommendedConfig,
+    "angular-recommended": angularRecommendedConfig,
+    "angular-template-recommended": angularTemplateRecommendedConfig,
   },
-  rules: {}
+  rules: {},
 };
 
 export default plugin;

--- a/src/utils/ignore-files-list.ts
+++ b/src/utils/ignore-files-list.ts
@@ -1,4 +1,4 @@
-export const ignores = [ 
+export const ignores = [
   "projects/**/*",
   "**/dist",
   "**/node_modules",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,1 @@
-export * from './ignore-files-list';
+export * from "./ignore-files-list";


### PR DESCRIPTION
Added missing usage of prettier eslint plugin and run `eslint --fix` on source.